### PR TITLE
Add ability to renew multiple certificates for a single site.

### DIFF
--- a/OhadSoft.AzureLetsEncrypt.Renewal/OhadSoft.AzureLetsEncrypt.Renewal.WebJob.Tests/RenewalTestBase.cs
+++ b/OhadSoft.AzureLetsEncrypt.Renewal/OhadSoft.AzureLetsEncrypt.Renewal.WebJob.Tests/RenewalTestBase.cs
@@ -22,6 +22,7 @@ namespace OhadSoft.AzureLetsEncrypt.Renewal.WebJob.Tests
         protected const string WebApp1 = WebApp1Name + "{" + SiteSlotName1 + "}";
         protected const string WebApp2 = "barApp";
         protected const string WebApp3 = "bazApp";
+        protected const string WebApp4 = WebApp1Name + "[barBaz]";
         protected const string Email1 = "foo@gmail.com";
         protected const string Email2 = "bar@outlook.com";
         protected const string EmailShared = "shared@yahoo.com";
@@ -40,6 +41,7 @@ namespace OhadSoft.AzureLetsEncrypt.Renewal.WebJob.Tests
         protected static readonly IReadOnlyList<string> Hosts1 = new[] { "www.foo.com" };
         protected static readonly IReadOnlyList<string> Hosts2 = new[] { "www.bar.com", "bar.com" };
         protected static readonly IReadOnlyList<string> Hosts3 = new[] { "www.shared.com" };
+        protected static readonly IReadOnlyList<string> Hosts4 = new[] { "www.barbaz.com", "barbaz.com" };
         protected static readonly Guid ClientId1 = Guid.Parse("89e5c1ee-a37b-4af7-89fc-217a4b99652c");
         protected static readonly Guid ClientId2 = Guid.Parse("618a929b-d9c9-4ec1-b8dc-66f55d949d52");
         protected static readonly Guid ClientIdShared = Guid.Parse("a06ff82d-7964-45a0-920f-22897ab9f9cb");
@@ -115,6 +117,16 @@ namespace OhadSoft.AzureLetsEncrypt.Renewal.WebJob.Tests
             AzureTokenAudienceShared,
             AzureManagementEndpointShared,
             AzureDefaultWebsiteDomainNameShared);
+
+        protected static readonly RenewalParameters ExpectedPartialRenewalParameters4 = new RenewalParameters(
+            Subscription1,
+            Tenant1,
+            ResourceGroup1,
+            WebApp1Name,
+            Hosts4,
+            Email1,
+            ClientId1,
+            ClientSecret1);
 
         protected RenewalManagerMock RenewalManager { get; } = new RenewalManagerMock();
         protected EmailNotifierMock EmailNotifier { get; } = new EmailNotifierMock();

--- a/OhadSoft.AzureLetsEncrypt.Renewal/OhadSoft.AzureLetsEncrypt.Renewal.WebJob.Tests/WebJob/AppSettingsTests.cs
+++ b/OhadSoft.AzureLetsEncrypt.Renewal/OhadSoft.AzureLetsEncrypt.Renewal.WebJob.Tests/WebJob/AppSettingsTests.cs
@@ -249,6 +249,24 @@ namespace OhadSoft.AzureLetsEncrypt.Renewal.WebJob.Tests.WebJob
             VerifySuccessfulNotification(ExpectedPartialRenewalParameters3);
         }
 
+        [TestMethod]
+        public async Task TestMultipleHostWebAppConfig()
+        {
+            m_appSettings[BuildConfigKey(WebAppsKey)] = WebApp4;
+            m_appSettings[BuildConfigKey(SubscriptionIdKeySuffix, WebApp4)] = Subscription1.ToString();
+            m_appSettings[BuildConfigKey(TenantIdKeySuffix, WebApp4)] = Tenant1;
+            m_appSettings[BuildConfigKey(ClientIdKeySuffix, WebApp4)] = ClientId1.ToString();
+            m_appSettings[BuildConfigKey(ClientSecretKeySuffix, WebApp4)] = ClientSecret1;
+            m_appSettings[BuildConfigKey(ResourceGroupKeySuffix, WebApp4)] = ResourceGroup1;
+            m_appSettings[BuildConfigKey(HostsKeySuffix, WebApp4)] = String.Join(";", Hosts4);
+            m_appSettings[BuildConfigKey(EmailKeySuffix, WebApp4)] = Email1;
+
+            await m_renewer.Renew();
+
+            VerifySuccessfulRenewal(ExpectedPartialRenewalParameters4);
+            VerifySuccessfulNotification(ExpectedPartialRenewalParameters4);
+        }
+
         private void AssertInvalidConfig(string key, string webApp, string value, string expectedText = null, bool testMissing = true, bool testShared = true)
         {
             var configKey = BuildConfigKey(key, webApp);

--- a/OhadSoft.AzureLetsEncrypt.Renewal/OhadSoft.AzureLetsEncrypt.Renewal.WebJob/AppSettings/AppSettingsRenewalParamsReader.cs
+++ b/OhadSoft.AzureLetsEncrypt.Renewal/OhadSoft.AzureLetsEncrypt.Renewal.WebJob/AppSettings/AppSettingsRenewalParamsReader.cs
@@ -65,7 +65,13 @@ namespace OhadSoft.AzureLetsEncrypt.Renewal.WebJob.AppSettings
             string webAppName = webApp;
             string siteSlotName = null;
 
-            var match = Regex.Match(webApp, "^(.*){(.*)}$");
+            var match = Regex.Match(webAppName, @"^(.*)\[.*\]$");
+            if (match.Success)
+            {
+                webAppName = match.Groups[1].Value;
+            }
+
+            match = Regex.Match(webAppName, "^(.*){(.*)}$");
             if (match.Success)
             {
                 webAppName = match.Groups[1].Value;

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ It is sometimes useful to share configuraiton settings beween web apps. For exam
 
 All settings except `hosts`may be shared.
 
+### Multiple Certificates for a Single Site
+If you have a site that supports many domain names, it can be useful to group them into separate certificates. In order to handle renewing multiple certificates associated with a single site, use the following syntax for the web app's name: `webAppName[groupName]` or `webAppName{siteSlotName}[groupName]`. For example, if you have a `foo` site that has two certificates that need to be updated, configure `letsencrypt:webApps` to be `foo;foo[Group2]`. You would still need to configure the regular settings for each of them (e.g. `letsencrypt:foo-subscriptionId`, `letsencrypt:foo[Group2]-subscriptionId` and so forth).
+
 ### Using the configuration script
 There is a PowerShell configuration-script [Set-LetsEncryptConfiguration.ps1](OhadSoft.AzureLetsEncrypt.Renewal/Scripts/Set-LetsEncryptConfiguration.ps1) which can be used to streamline the configuration of multiple Web Apps. Running the script is straightfoward, and further documentation resides inside it.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ It is sometimes useful to share configuraiton settings beween web apps. For exam
 
 All settings except `hosts`may be shared.
 
-### Multiple Certificates for a Single Site
+### Multiple certificates for a single site
 If you have a site that supports many domain names, it can be useful to group them into separate certificates. In order to handle renewing multiple certificates associated with a single site, use the following syntax for the web app's name: `webAppName[groupName]` or `webAppName{siteSlotName}[groupName]`. For example, if you have a `foo` site that has two certificates that need to be updated, configure `letsencrypt:webApps` to be `foo;foo[Group2]`. You would still need to configure the regular settings for each of them (e.g. `letsencrypt:foo-subscriptionId`, `letsencrypt:foo[Group2]-subscriptionId` and so forth).
 
 ### Using the configuration script


### PR DESCRIPTION
I needed the ability to update multiple certificates associated with a single site, and this seemed to do the trick for me. One negative with it is that the settings between the base site configuration and the group configurations are not shared. It doesn't impact me because all my settings are shared except for hosts, but it may cause pain to others. If you think this change is useful enough to accept, I'd be happy to go back and add the ability for the group configurations to inherit from the base configuration.