### PR TITLE
Downgraded Microsoft.Azure.Management.Websites

### DIFF
--- a/OhadSoft.AzureLetsEncrypt.Renewal/OhadSoft.AzureLetsEncrypt.Renewal.WebJob/App.config
+++ b/OhadSoft.AzureLetsEncrypt.Renewal/OhadSoft.AzureLetsEncrypt.Renewal.WebJob/App.config
@@ -34,10 +34,6 @@
         <bindingRedirect oldVersion="0.0.0.0-1.8.3.0" newVersion="1.8.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.Management.Websites" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Microsoft.Azure.Management.Dns" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
       </dependentAssembly>

--- a/OhadSoft.AzureLetsEncrypt.Renewal/OhadSoft.AzureLetsEncrypt.Renewal.WebJob/OhadSoft.AzureLetsEncrypt.Renewal.WebJob.csproj
+++ b/OhadSoft.AzureLetsEncrypt.Renewal/OhadSoft.AzureLetsEncrypt.Renewal.WebJob/OhadSoft.AzureLetsEncrypt.Renewal.WebJob.csproj
@@ -43,7 +43,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x86\Debug\</OutputPath>
+    <OutputPath>bin\x86\dbg\</OutputPath>
     <DefineConstants>CODE_ANALYSIS;DEBUG;TRACE</DefineConstants>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugType>full</DebugType>

--- a/OhadSoft.AzureLetsEncrypt.Renewal/OhadSoft.AzureLetsEncrypt.Renewal/OhadSoft.AzureLetsEncrypt.Renewal.csproj
+++ b/OhadSoft.AzureLetsEncrypt.Renewal/OhadSoft.AzureLetsEncrypt.Renewal/OhadSoft.AzureLetsEncrypt.Renewal.csproj
@@ -109,7 +109,7 @@
       <Version>3.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.Management.Websites">
-      <Version>2.0.0</Version>
+      <Version>1.6.0-preview</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory">
       <Version>2.29.0</Version>

--- a/OhadSoft.AzureLetsEncrypt.Renewal/OhadSoft.AzureLetsEncrypt.Renewal/app.config
+++ b/OhadSoft.AzureLetsEncrypt.Renewal/OhadSoft.AzureLetsEncrypt.Renewal/app.config
@@ -27,10 +27,6 @@
         <bindingRedirect oldVersion="0.0.0.0-1.8.3.0" newVersion="1.8.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.Management.Websites" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Microsoft.Azure.Management.Dns" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
       </dependentAssembly>


### PR DESCRIPTION
Nexessary due to LetsEncrypt.Azure.Core dependency (API change)
Shortened output folder to prevent 260 path characters issues