### PR TITLE
Update packages to support User Managed Identities

### DIFF
--- a/OhadSoft.AzureLetsEncrypt.Renewal/OhadSoft.AzureLetsEncrypt.Renewal/OhadSoft.AzureLetsEncrypt.Renewal.csproj
+++ b/OhadSoft.AzureLetsEncrypt.Renewal/OhadSoft.AzureLetsEncrypt.Renewal/OhadSoft.AzureLetsEncrypt.Renewal.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -113,7 +113,7 @@
       <Version>3.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.Management.Websites">
-      <Version>2.1.0</Version>
+      <Version>2.2.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory">
       <Version>4.5.1</Version>

--- a/OhadSoft.AzureLetsEncrypt.Renewal/OhadSoft.AzureLetsEncrypt.Renewal/OhadSoft.AzureLetsEncrypt.Renewal.csproj
+++ b/OhadSoft.AzureLetsEncrypt.Renewal/OhadSoft.AzureLetsEncrypt.Renewal/OhadSoft.AzureLetsEncrypt.Renewal.csproj
@@ -125,7 +125,7 @@
       <Version>3.3.19</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.Authentication">
-      <Version>2.3.8</Version>
+      <Version>2.4.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>12.0.2</Version>


### PR DESCRIPTION
When trying to use this against an App Service that has a User Managed Identity, you receive the following error:

`The identity ids must not be null or empty for 'UserAssigned' identity type.`

This is due to the version of Microsoft.Azure.Management.Websites. I updated from 2.1.0 to 2.2.0 which fixes it. 

Note: If using User Managed Identities, you additionally need to give "Managed Identity Operator" on the Managed Identity to the App Registration.

I also updated the version of Microsoft.Rest.ClientRuntime.Azure.Authentication  from 2.3.8 to 2.4.0 as the current version is actually unlisted on NuGet.