### PR TITLE
README: Added remarks about Internationalized Domain Names

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ You may use the ACME DNS challenge instead of the HTTP challenge. Currently only
 ### Remarks about Internationalized Domain Names (IDNs)
 If you use an Internationalized Domain Name (IDN), note these remarks:
 - You will have to enter your IDN hostnames (i.e. with special characters) into `letsencrypt:webAppName-hosts` (e.g. `myümlautdomain.de;www.myümlautdomain.de`).
-- You will have to enter your ACN encoded domain name into `letsencrypt:webAppName-azureDnsZoneName` (e.g `xn--mymlautdomain-xob.de`)
+- You will have to enter your ACE-prefixed punycode-encoded domain name into `letsencrypt:webAppName-azureDnsZoneName` (e.g `xn--mymlautdomain-xob.de`)
 
 ### Site Deployment Slots
 In order to specify a Site Deployment Slot for a given web app, use the following syntax for the web app's name: `webAppName{siteSlotName}`. For example, if you have a `foo` site with no deployment slots and a `bar` site with `staging` and `prod` deployment slots, configure `letsencrypt:webApps` to be `foo;bar{staging};bar{prod}`. Different deployment slots are treated as different web apps and the normal setting rules apply, so you would still need to configure the regular settings for each of them (e.g. `letsencrypt:foo-subscriptionId`, `letsencrypt:bar{staging}-subscriptionId`, `letsencrypt:bar{prod}-subscriptionId` and so forth). 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ You may use the ACME DNS challenge instead of the HTTP challenge. Currently only
 6. `letsencrypt:webAppName-azureDnsClientId` (optional, defaults to Web App Client ID)
 7. `letsencrypt:webAppName-azureDnsClientSecret` (optional, defaults to Web App Client Secret)
 
+### Remarks about Internationalized Domain Names (IDNs)
+If you use an Internationalized Domain Name (IDN), here are additional information:
+- You'll have to enter your hostnames with special characters into  `letsencrypt:webAppName-hosts` (e.g. `myümlautdomain.de,www.myümlautdomain.de`).
+- You'll have to enter your encoded hostname into `letsencrypt:webAppName-azureDnsZoneName` (e.g `xn--mymlautdomain-xob.de`)
+
 ### Site Deployment Slots
 In order to specify a Site Deployment Slot for a given web app, use the following syntax for the web app's name: `webAppName{siteSlotName}`. For example, if you have a `foo` site with no deployment slots and a `bar` site with `staging` and `prod` deployment slots, configure `letsencrypt:webApps` to be `foo;bar{staging};bar{prod}`. Different deployment slots are treated as different web apps and the normal setting rules apply, so you would still need to configure the regular settings for each of them (e.g. `letsencrypt:foo-subscriptionId`, `letsencrypt:bar{staging}-subscriptionId`, `letsencrypt:bar{prod}-subscriptionId` and so forth). 
 

--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ You may use the ACME DNS challenge instead of the HTTP challenge. Currently only
 7. `letsencrypt:webAppName-azureDnsClientSecret` (optional, defaults to Web App Client Secret)
 
 ### Remarks about Internationalized Domain Names (IDNs)
-If you use an Internationalized Domain Name (IDN), here are additional information:
-- You'll have to enter your hostnames with special characters into  `letsencrypt:webAppName-hosts` (e.g. `myümlautdomain.de,www.myümlautdomain.de`).
-- You'll have to enter your encoded hostname into `letsencrypt:webAppName-azureDnsZoneName` (e.g `xn--mymlautdomain-xob.de`)
+If you use an Internationalized Domain Name (IDN), note these remarks:
+- You will have to enter your IDN hostnames (i.e. with special characters) into `letsencrypt:webAppName-hosts` (e.g. `myümlautdomain.de;www.myümlautdomain.de`).
+- You will have to enter your ACN encoded domain name into `letsencrypt:webAppName-azureDnsZoneName` (e.g `xn--mymlautdomain-xob.de`)
 
 ### Site Deployment Slots
 In order to specify a Site Deployment Slot for a given web app, use the following syntax for the web app's name: `webAppName{siteSlotName}`. For example, if you have a `foo` site with no deployment slots and a `bar` site with `staging` and `prod` deployment slots, configure `letsencrypt:webApps` to be `foo;bar{staging};bar{prod}`. Different deployment slots are treated as different web apps and the normal setting rules apply, so you would still need to configure the regular settings for each of them (e.g. `letsencrypt:foo-subscriptionId`, `letsencrypt:bar{staging}-subscriptionId`, `letsencrypt:bar{prod}-subscriptionId` and so forth). 


### PR DESCRIPTION
I just ran into a wall when trying to set up letsencrypt-webapp-renewer with a hostname that has an Internationalized Domain Name (IDN). To avoid other people running into the same wall, I'd like to propose the small addition to the README.MD [as you can see](https://github.com/ohadschn/letsencrypt-webapp-renewer/pull/89/files) in this pull request.