### PR TITLE
Let's Encrypt certificates are issued by R3, R4, E1 or E2 now.

### DIFF
--- a/src/OhadSoft.AzureLetsEncrypt.Renewal/Util/CertificateHelper.cs
+++ b/src/OhadSoft.AzureLetsEncrypt.Renewal/Util/CertificateHelper.cs
@@ -50,7 +50,8 @@ namespace OhadSoft.AzureLetsEncrypt.Renewal.Util
                 Trace.TraceInformation("Reading ARM certificate query response");
                 var body = await response.EnsureSuccessStatusCode().Content.ReadAsStringAsync().ConfigureAwait(false);
 
-                var letsEncryptCerts = ExtractCertificates(body).Where(s => s.Issuer.Contains(staging ? "Fake LE" : "Let's Encrypt"));
+                var issuerNames = staging ? new[] { "Fake LE" } : new[] { "Let's Encrypt", "R3", "R4", "E1", "E2" };
+                var letsEncryptCerts = ExtractCertificates(body).Where(s => issuerNames.Any(i => s.Issuer.StartsWith(i)));
 
                 var leCertThumbprints = new HashSet<string>(letsEncryptCerts.Select(c => c.Thumbprint));
                 return site.HostNameSslStates.Where(ssl => leCertThumbprints.Contains(ssl.Thumbprint)).Select(ssl => ssl.Name).ToArray();


### PR DESCRIPTION
See https://letsencrypt.org/certificates/

This PR avoids that new certificates are issued every time instead of renewing them.