### PR TITLE
Package and framework updates

### DIFF
--- a/src/OhadSoft.AzureLetsEncrypt.Renewal.WebJob.Tests/OhadSoft.AzureLetsEncrypt.Renewal.WebJob.Tests.csproj
+++ b/src/OhadSoft.AzureLetsEncrypt.Renewal.WebJob.Tests/OhadSoft.AzureLetsEncrypt.Renewal.WebJob.Tests.csproj
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
+  <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{DF035A8A-E58B-43E0-BA8A-E07281DE5AE9}</ProjectGuid>
@@ -8,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OhadSoft.AzureLetsEncrypt.Renewal.WebJob.Tests</RootNamespace>
     <AssemblyName>OhadSoft.AzureLetsEncrypt.Renewal.WebJob.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>

--- a/src/OhadSoft.AzureLetsEncrypt.Renewal.WebJob.Tests/app.config
+++ b/src/OhadSoft.AzureLetsEncrypt.Renewal.WebJob.Tests/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/src/OhadSoft.AzureLetsEncrypt.Renewal.WebJob/App.config
+++ b/src/OhadSoft.AzureLetsEncrypt.Renewal.WebJob/App.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup> 
-      <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
+      <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
   </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
@@ -11,39 +11,39 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Certes" publicKeyToken="308b9c08e7effcb1" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.3.3.0" newVersion="2.3.3.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.0.4.0" newVersion="3.0.4.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Azure.KeyVault.Core" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.4.0" newVersion="3.1.4.0" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.4.0" newVersion="3.1.4.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.4.0" newVersion="3.1.4.0" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.4.0" newVersion="3.1.4.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.4.0" newVersion="3.1.4.0" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.4.0" newVersion="3.1.4.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.4.0" newVersion="3.1.4.0" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.4.0" newVersion="3.1.4.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.4.0" newVersion="3.1.4.0" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.4.0" newVersion="3.1.4.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.4.0" newVersion="3.1.4.0" />
+        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.4.0" newVersion="3.1.4.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.4.0" newVersion="3.1.4.0" />
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.4.0" newVersion="3.1.4.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
@@ -55,11 +55,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
@@ -70,12 +70,12 @@
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/OhadSoft.AzureLetsEncrypt.Renewal.WebJob/OhadSoft.AzureLetsEncrypt.Renewal.WebJob.csproj
+++ b/src/OhadSoft.AzureLetsEncrypt.Renewal.WebJob/OhadSoft.AzureLetsEncrypt.Renewal.WebJob.csproj
@@ -2,13 +2,17 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
+  <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{B8C64DE4-15EC-4935-8891-85245E97E48B}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <RootNamespace>OhadSoft.AzureLetsEncrypt.Renewal.WebJob</RootNamespace>
     <AssemblyName>AzureLetsEncryptRenewer</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <NuGetPackageImportStamp>
@@ -141,7 +145,7 @@
       <Version>2.0.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.3</Version>
+      <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="Sendgrid">
       <Version>9.15.1</Version>

--- a/src/OhadSoft.AzureLetsEncrypt.Renewal.sln
+++ b/src/OhadSoft.AzureLetsEncrypt.Renewal.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26430.16
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33627.172
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OhadSoft.AzureLetsEncrypt.Renewal", "OhadSoft.AzureLetsEncrypt.Renewal\OhadSoft.AzureLetsEncrypt.Renewal.csproj", "{7173122F-CF8B-4D1E-9CC5-E3EC479ED6F8}"
 EndProject

--- a/src/OhadSoft.AzureLetsEncrypt.Renewal/OhadSoft.AzureLetsEncrypt.Renewal.csproj
+++ b/src/OhadSoft.AzureLetsEncrypt.Renewal/OhadSoft.AzureLetsEncrypt.Renewal.csproj
@@ -2,6 +2,10 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
+  <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{7173122F-CF8B-4D1E-9CC5-E3EC479ED6F8}</ProjectGuid>
@@ -9,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OhadSoft.AzureLetsEncrypt.Renewal</RootNamespace>
     <AssemblyName>OhadSoft.AzureLetsEncrypt.Renewal</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -106,8 +110,8 @@
     <PackageReference Include="BouncyCastle">
       <Version>1.8.6.1</Version>
     </PackageReference>
-    <PackageReference Include="letsencrypt.azure.core">
-      <Version>1.0.5</Version>
+    <PackageReference Include="letsencrypt.azure.core.untested">
+      <Version>1.0.7</Version>
     </PackageReference>
     <PackageReference Include="LetsEncrypt.Azure.Core.V2">
       <Version>1.0.132</Version>
@@ -139,7 +143,7 @@
       <Version>2.4.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.3</Version>
+      <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="SonarAnalyzer.CSharp">
       <Version>8.8.0.18411</Version>

--- a/src/OhadSoft.AzureLetsEncrypt.Renewal/OhadSoft.AzureLetsEncrypt.Renewal.csproj
+++ b/src/OhadSoft.AzureLetsEncrypt.Renewal/OhadSoft.AzureLetsEncrypt.Renewal.csproj
@@ -108,13 +108,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BouncyCastle">
-      <Version>1.8.6.1</Version>
+      <Version>1.8.9</Version>
     </PackageReference>
     <PackageReference Include="letsencrypt.azure.core.untested">
       <Version>1.0.7</Version>
     </PackageReference>
-    <PackageReference Include="LetsEncrypt.Azure.Core.V2">
-      <Version>1.0.132</Version>
+    <PackageReference Include="LetsEncrypt.Azure.Core.V2.untested">
+      <Version>1.0.134</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.Management.Dns">
       <Version>3.0.1</Version>

--- a/src/OhadSoft.AzureLetsEncrypt.Renewal/app.config
+++ b/src/OhadSoft.AzureLetsEncrypt.Renewal/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>


### PR DESCRIPTION
Hello,

I appreciate this is essentially deprecated, but it is still useful for me and likely some others

The webjob currently does not work due to an issue with older versions of Certes containing hardcoded chains:
https://community.letsencrypt.org/t/can-not-find-issuer-c-us-o-internet-security-research-group-cn-isrg-root-x1-for-certificate-c-us-o-lets-encrypt-cn-r3/208268/6

New versions of Certes have fixed this issue, and the author of the letsencrypt.azure.core NuGet package has kindly agreed to update the dependencies on their end, but untested/unsupported

This PR will update this project to use the untested/unsupported package, thus no longer using hardcoded chains and should unblock